### PR TITLE
Better handling of multiple mimes on versions of Android

### DIFF
--- a/app/GoNativeActivity.java
+++ b/app/GoNativeActivity.java
@@ -8,6 +8,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputType;
@@ -105,7 +106,12 @@ public class GoNativeActivity extends NativeActivity {
 
     void doShowFileOpen(String mimes) {
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.setType(mimes);
+        if (mimes.contains("|") && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            intent.setType("*/*");
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, mimes.split("\\|"));
+        } else {
+            intent.setType(mimes);
+        }
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         startActivityForResult(Intent.createChooser(intent, "Open File"), FILE_OPEN_CODE);
     }

--- a/app/android.go
+++ b/app/android.go
@@ -68,6 +68,11 @@ import (
 	"github.com/fyne-io/mobile/internal/mobileinit"
 )
 
+// mimeMap contains standard mime entries that are missing on Android
+var mimeMap = map[string]string{
+	".txt": "text/plain",
+}
+
 // RunOnJVM runs fn on a new goroutine locked to an OS thread with a JNIEnv.
 //
 // RunOnJVM blocks until the call to fn is complete. Any Java
@@ -338,10 +343,16 @@ func driverShowFileOpenPicker(callback func(string, func()), filter *FileFilter)
 
 	mimes := "*/*"
 	if filter.MimeTypes != nil {
-		mimes = strings.Join(filter.MimeTypes, ",")
+		mimes = strings.Join(filter.MimeTypes, "|")
 	} else if filter.Extensions != nil {
 		var mimeTypes []string
 		for _, ext := range filter.Extensions {
+			if mimeEntry, ok := mimeMap[ext]; ok {
+				mimeTypes = append(mimeTypes, mimeEntry)
+
+				continue
+			}
+
 			mimeType := mime.TypeByExtension(ext)
 			if mimeType == "" {
 				continue
@@ -349,7 +360,7 @@ func driverShowFileOpenPicker(callback func(string, func()), filter *FileFilter)
 
 			mimeTypes = append(mimeTypes, mimeType)
 		}
-		mimes = strings.Join(mimeTypes, ",")
+		mimes = strings.Join(mimeTypes, "|")
 	}
 	mimeStr := C.CString(mimes)
 	defer C.free(unsafe.Pointer(mimeStr))


### PR DESCRIPTION
New API is better supported, older one is just pipe list.
Also start list of mimes that seemed to be missing on the go lookup side...