### PR TITLE
app: support C compiler that defaults to -fno-common

### DIFF
--- a/app/android.go
+++ b/app/android.go
@@ -35,8 +35,8 @@ package app
 #include <pthread.h>
 #include <stdlib.h>
 
-EGLDisplay display;
-EGLSurface surface;
+extern EGLDisplay display;
+extern EGLSurface surface;
 
 char* createEGLSurface(ANativeWindow* window);
 char* destroyEGLSurface();


### PR DESCRIPTION
For the Android NDK, between r21 and r22 the NDK compiler switched the
default from "-fcommon" to "-fno-common", which causes duplicate
definitions when building the examples given the current C code. To
fix things, rework the C code to insure that we have a single
definition and an "extern" reference to the objects in question.

Copied from here:
https://github.com/golang/mobile/commit/f462b3930c8f01e0d9daa52b47ac887019ffa5b0